### PR TITLE
BUG: adds missing package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     },
     package_data={
         'q2_sample_classifier.tests': ['test_data/*'],
+        'q2_sample_classifier': ['assets/index.html'],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
When installing with pip (without `-e`), running visualizers fails without this package data. 